### PR TITLE
add doc rockable

### DIFF
--- a/sphinxdoc/source/quickStart.rst
+++ b/sphinxdoc/source/quickStart.rst
@@ -80,6 +80,52 @@ It is sometimes necessary to remove all object files (.o) together with the comp
 
    make clean
 
+Compilation with spack
+----------------------
+
+
+This external library is available here: https://github.com/richefeu/rockable, this installation does not require direct download of `Rockable`.
+
+Installation of `Rockable` via `spack`:
+
+.. code-block:: bash
+  
+  git clone git clone --depth=2 --branch=v0.23.0 https://github.com/spack/spack.git
+  source spack/share/spack/setup-env.sh
+  git clone https://github.com/Collab4exaNBody/spack-repos.git
+  spack repo add spack-repos
+  spack external find opengl
+  spack install rockable+see
+
+
+Use `Rockable`:
+
+.. code-block:: bash
+
+  spack load rockable
+  rockable file.conf -j 10
+  see conf0
+
+Available options:
+
+.. code-block:: bash
+
+    conftovtk [true]            false, true
+        Convert conf files to VTK
+    postpro [false]             false, true
+        Compile the application to run post-processing commands
+    prepro [true]               false, true
+        Compile the preprocessing tools
+    see [true]                  false, true
+        Compile the glut application to visualize the conf-files
+    see2 [false]                false, true
+        Compile the glfw application to visualize the conf-files
+    see3 [false]                false, true
+        Compile the application to edit graphically the input files
+
+.. warning::
+
+  * Not all option combinations are tested continuously. 
 
 Running a simulation
 --------------------


### PR DESCRIPTION
Spack package example is available here:  https://github.com/Collab4exaNBody/spack-repos/tree/main/packages/rockable

The spack installation documentation is available in the quicStart section.  

```
from spack import *

class Rockable(CMakePackage):
    """Rockable is a DEM Simulation Code.
		"""

    homepage = "https://github.com/richefeu/rockable"
    git = "https://github.com/richefeu/rockable.git"

    version("main", git='https://github.com/richefeu/rockable.git',  branch='main') 
    version("1.0.0", git={'https://github.com/richefeu/rockable.git', tag='1.0.0', preferred=True )
	
    variant("see", default=True, description="Compile the glut application to visualize the conf-files")
    variant("see2", default=False, description="Compile the glfw application to visualize the conf-files")
    variant("see3", default=False, description="Compile the application to edit graphically the input files")
    variant("postpro", default=False, description="Compile the application to run post-processing commands")
    variant("prepro", default=True, description="Compile the preprocessing tools")
    variant("conftovtk", default=True, description="Convert conf files to VTK")

    depends_on("cmake@3.27.9")
    depends_on("opengl" , when="+see")
#    depends_on("mesa-glu", when="+see")
    depends_on("libpng", when="+see")
#    depends_on("openglu@1.3", when="+see")
#    depends_on("freeglut", when="+see")
    depends_on("glfw" , when="+see3")
    depends_on("glfw" , when="+see2")
    depends_on("pkg-config")

    def setup_run_environment(self, env):
        env.set('rockable_DIR', self.prefix)

    def cmake_args(self):
        args = [self.define_from_variant("ROCKABLE_COMPILE_SEE", "see"), self.define_from_variant("ROCKABLE_COMPILE_SEE2", "see2") , self.define_from_variant("ROCKABLE_COMPILE_SEE3", "see3") , self.define_from_variant("ROCKABLE_COMPILE_POSTPRO", "postpro") , self.define_from_variant("ROCKABLE_COMPILE_PREPRO", "prepro") , self.define_from_variant("ROCKABLE_COMPILE_CONF2VTK", "conftovtk") ]
        return args
```