### PR TITLE
Fix periodic boundary conditions based on Radjai 2011 book (chapter 7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ if(ROCKABLE_ENABLE_BOUNDARY)
   add_compile_options(-DROCKABLE_ENABLE_BOUNDARY)
 endif()
 
+if(ROCKABLE_ENABLE_PERIODIC)
+  add_compile_options(-DROCKABLE_ENABLE_PERIODIC)
+endif()
+
 # get the git tag of Rockable
 execute_process(
   COMMAND git describe --abbrev=0 --tags --always

--- a/src/Core/DrivingSystem.cpp
+++ b/src/Core/DrivingSystem.cpp
@@ -80,9 +80,9 @@ void DrivingSystem::read(bool allow_warn) {
         cellControl.Drive.xz = cellControl.Drive.zx = VelocityDriven;
         cellControl.Drive.yz = cellControl.Drive.zy = VelocityDriven;
 
-        cellControl.Sig.xx = cellControl.Sig.yy = cellControl.Sig.zz = pressure;
+        cellControl.Sig.xx = cellControl.Sig.yy = cellControl.Sig.zz = -pressure;
         cellControl.Sig.xy = cellControl.Sig.yx = 0.0;
-        cellControl.Sig.xz = cellControl.Sig.yz = 0.0;
+        cellControl.Sig.xz = cellControl.Sig.zx = 0.0;
         cellControl.Sig.yz = cellControl.Sig.zy = 0.0;
 
         cellControl.v.xx = cellControl.v.yy = cellControl.v.zz = 0.0;  // free in fact
@@ -91,6 +91,81 @@ void DrivingSystem::read(bool allow_warn) {
         cellControl.v.yz = cellControl.v.zy = 0.0;
 
         ServoFunction = nullptr;
+      } else if (LoadingName == "TriaxialCompression") {
+
+        std::string dirStr;
+        double pressure, strainRate;
+        is >> dirStr >> pressure >> strainRate;
+
+        cellControl.Drive.xx = cellControl.Drive.yy = cellControl.Drive.zz = ForceDriven;
+        cellControl.Sig.xx = cellControl.Sig.yy = cellControl.Sig.zz = -pressure;
+
+        cellControl.Drive.xy = cellControl.Drive.yx = VelocityDriven;
+        cellControl.Drive.xz = cellControl.Drive.zx = VelocityDriven;
+        cellControl.Drive.yz = cellControl.Drive.zy = VelocityDriven;
+        cellControl.v.xy = cellControl.v.yx = 0.0;
+        cellControl.v.xz = cellControl.v.zx = 0.0;
+        cellControl.v.yz = cellControl.v.zy = 0.0;
+
+        size_t activeIdx = 0;
+        if (dirStr == "X")
+          activeIdx = 0;
+        else if (dirStr == "Y")
+          activeIdx = 4;
+        else if (dirStr == "Z")
+          activeIdx = 8;
+        else {
+          std::cerr << "Error: TriaxialCompression direction must be X, Y, or Z." << std::endl;
+        }
+
+        cellControl.Drive[activeIdx] = VelocityDriven;
+        ServoFunction = [activeIdx, strainRate](Rockable& box) -> void {
+          box.System.cellControl.v[activeIdx] = strainRate * box.Cell.h[activeIdx];
+        };
+      } else if (LoadingName == "SimpleShearDeformable") {
+
+        std::string dirStr;
+        double pressure, shearRate;
+        is >> dirStr >> pressure >> shearRate;
+
+        cellControl.Drive.xx = cellControl.Drive.yy = cellControl.Drive.zz = ForceDriven;
+        cellControl.Sig.xx = cellControl.Sig.yy = cellControl.Sig.zz = -pressure;
+
+        cellControl.Drive.xy = cellControl.Drive.xz = VelocityDriven;
+        cellControl.Drive.yx = cellControl.Drive.yz = VelocityDriven;
+        cellControl.Drive.zx = cellControl.Drive.zy = VelocityDriven;
+
+        for (int k = 0; k < 9; ++k)
+          cellControl.v[k] = 0.0;
+
+        size_t shearIdx = 0;
+        size_t normalIdx = 0;
+        if (dirStr == "XY") {
+          shearIdx = 1;
+          normalIdx = 1;
+        } else if (dirStr == "XZ") {
+          shearIdx = 2;
+          normalIdx = 2;
+        } else if (dirStr == "YX") {
+          shearIdx = 3;
+          normalIdx = 0;
+        } else if (dirStr == "YZ") {
+          shearIdx = 5;
+          normalIdx = 2;
+        } else if (dirStr == "ZX") {
+          shearIdx = 6;
+          normalIdx = 0;
+        } else if (dirStr == "ZY") {
+          shearIdx = 7;
+          normalIdx = 1;
+        } else {
+          std::cerr << "Error: Unknown shear direction '" << dirStr << "'." << std::endl;
+        }
+
+        ServoFunction = [shearIdx, normalIdx, shearRate](Rockable& box) -> void {
+          size_t h_idx = normalIdx * 4;
+          box.System.cellControl.v[shearIdx] = shearRate * box.Cell.h[h_idx];
+        };
       }
 
     } else if (token == "Control") {

--- a/src/Core/PeriodicCell.cpp
+++ b/src/Core/PeriodicCell.cpp
@@ -43,7 +43,11 @@ PeriodicCell::PeriodicCell(double XX, double XY, double XZ, double YX, double YY
                            double ZZ)
     : h(XX, XY, XZ, YX, YY, YZ, ZX, ZY, ZZ), vh(), ah() {}
 
-void PeriodicCell::precomputeInverse() { hinv = h.get_inverse(); }
+void PeriodicCell::precomputeInverse() {
+  hinv = h.get_inverse();
+  vhHinv = vh * hinv;
+  hinvVh = hinv * vh;
+}
 
 /// @brief Get the branch correction to account for the periodicity.
 ///
@@ -52,7 +56,7 @@ void PeriodicCell::precomputeInverse() { hinv = h.get_inverse(); }
 /// @return vec3r a vector (real coordinates) to be add to the position of the second body. If this vector is non-zero,
 ///               then adding it to the position of j will be its image
 ///
-vec3r PeriodicCell::getBranchCorrection(const vec3r& ipos, const vec3r& jpos) {
+vec3r PeriodicCell::getBranchCorrection(const vec3r& ipos, const vec3r& jpos) const {
   vec3r rij = ipos - jpos;  // the branch vector from i to j
   vec3r sij = hinv * rij;   // same vector in reduced coordinates
 
@@ -67,7 +71,7 @@ vec3r PeriodicCell::getBranchCorrection(const vec3r& ipos, const vec3r& jpos) {
 ///
 /// @param s the reduced coordinate to be modified
 ///
-void PeriodicCell::forceToStayInside(vec3r& s) {
+void PeriodicCell::forceToStayInside(vec3r& s) const {
   s.x -= floor(s.x);
   s.y -= floor(s.y);
   s.z -= floor(s.z);

--- a/src/Core/PeriodicCell.hpp
+++ b/src/Core/PeriodicCell.hpp
@@ -40,19 +40,22 @@
 
 class PeriodicCell {
  public:
-  mat9r h;      ///< Matrix that hold the cell geometry (each column is a vector that defines a side)
-  mat9r hinv;   ///< inverse of matrix h (recomputed each time h is updated)
-  mat9r vh;     ///< Velocities of the collective DoF
-  mat9r ah;     ///< Acceleration of the collective DoF
-  mat9r Sig;    ///< Mean stress matrix over the cell
-  double mass;  ///< Mass of the periodic cell (a somehow fictive data)
+  mat9r h;                    ///< Matrix that hold the cell geometry (each column is a vector that defines a side)
+  mat9r hinv;                 ///< inverse of matrix h (recomputed each time h is updated)
+  mat9r vh;                   ///< Velocities of the collective DoF
+  mat9r ah;                   ///< Acceleration of the collective DoF
+  mat9r vhHinv;               ///< Cached composite matrix vh * hinv (Spatial Velocity Gradient)
+  mat9r hinvVh;               ///< Cached composite matrix hinv * vh (Convected Velocity Gradient)
+  mat9r Sig;                  ///< Mean stress matrix over the cell
+  double mass = 1.0;          ///< Mass of the periodic cell (a somehow fictive data)
+  double damping = 0.0;       ///< Damping coefficient for periodic cell dynamics (1/time)
+  double dampingRatio = 0.0;  ///< Stores dh / dh_critical
 
   PeriodicCell();
   PeriodicCell(double XX, double XY, double XZ, double YX, double YY, double YZ, double ZX, double ZY, double ZZ);
-  void Define(double XX, double XY, double XZ, double YX, double YY, double YZ, double ZX, double ZY, double ZZ);
   void precomputeInverse();
-  vec3r getBranchCorrection(const vec3r& ipos, const vec3r& jpos);
-  void forceToStayInside(vec3r& s);
+  vec3r getBranchCorrection(const vec3r& ipos, const vec3r& jpos) const;
+  void forceToStayInside(vec3r& s) const;
 };
 
 #endif /* end of include guard: PERIODICCELL_HPP */

--- a/src/Core/Rockable.cpp
+++ b/src/Core/Rockable.cpp
@@ -44,9 +44,9 @@
 #include "DataExtractors/DataExtractor_DuoBalance.hpp"
 #include "DataExtractors/DataExtractor_MeanVelocity.hpp"
 #include "DataExtractors/DataExtractor_TrackBody.hpp"
+#include "DataExtractors/DataExtractor_TrackDamage.hpp"
 #include "DataExtractors/DataExtractor_TrackRockfall.hpp"
 #include "DataExtractors/DataExtractor_dnStat.hpp"
-#include "DataExtractors/DataExtractor_TrackDamage.hpp"
 
 #include "ForceLaws/ForceLaw_Avalanche.hpp"
 #include "ForceLaws/ForceLaw_BCM.hpp"
@@ -98,6 +98,12 @@ Rockable::Rockable() : m_linkCells(aabb, cellMinSizes) {
 
 #ifdef ROCKABLE_ENABLE_PERIODIC
   usePeriodicCell = 0;
+  cellMomentumCorrection = 0.0;
+  cellMomentumCorrectionC = 0.0;
+  cellVelocityCorrection = 0.0;
+  cellVelocityCorrectionC = 0.0;
+  cellMassRatio = -1.0;
+  useKineticStress = true;
 #endif
 
   useSoftParticles = 0;
@@ -514,7 +520,11 @@ void Rockable::saveConf(const char* fname) {
     conf << "h " << Cell.h << '\n';
     conf << "vh " << Cell.vh << '\n';
     conf << "ah " << Cell.ah << '\n';
-    conf << "mh " << Cell.mass << '\n';
+    conf << "mh " << cellMassRatio << '\n';
+    conf << "dh " << Cell.damping << '\n';
+    conf << "cellMomentumCorrection " << cellMomentumCorrection << '\n';
+    conf << "cellVelocityCorrection " << cellVelocityCorrection << '\n';
+    conf << "useKineticStress " << useKineticStress << '\n';
   } else {
     conf << "usePeriodicCell 0\n";
   }
@@ -557,7 +567,7 @@ void Rockable::saveConf(const char* fname) {
   writeLawData(conf, "mom0OuterBond");
   writeLawData(conf, "powOuterBond");
   writeLawData(conf, "en2OuterBond");
-  
+
   writeLawData(conf, "gcInnerBond");
   writeLawData(conf, "gcOuterBond");
 
@@ -582,9 +592,9 @@ void Rockable::saveConf(const char* fname) {
          << Particles[i].homothety << ' ' << Particles[i].pos << ' ' << Particles[i].vel << ' ' << Particles[i].acc
          << ' ' << Particles[i].Q << ' ' << Particles[i].vrot << ' ' << Particles[i].arot;
     if (useSoftParticles == 1) {
-      //conf << ' ' << Particles[i].uniformTransformation << '\n';
+      // conf << ' ' << Particles[i].uniformTransformation << '\n';
     } else {
-      //conf << '\n';
+      // conf << '\n';
     }
   }
 
@@ -703,7 +713,11 @@ void Rockable::initParser() {
   parser.kwMap["h"] = __GET__(conf, Cell.h);
   parser.kwMap["vh"] = __GET__(conf, Cell.vh);
   parser.kwMap["ah"] = __GET__(conf, Cell.ah);
-  parser.kwMap["mh"] = __GET__(conf, Cell.mass);
+  parser.kwMap["mh"] = __GET__(conf, cellMassRatio);
+  parser.kwMap["dh"] = __GET__(conf, Cell.damping);
+  parser.kwMap["cellMomentumCorrection"] = __GET__(conf, cellMomentumCorrection);
+  parser.kwMap["cellVelocityCorrection"] = __GET__(conf, cellVelocityCorrection);
+  parser.kwMap["useKineticStress"] = __GET__(conf, useKineticStress);
 #endif
 
   parser.kwMap["useSoftParticles"] = __DO__(conf) {
@@ -848,7 +862,7 @@ void Rockable::initParser() {
   parser.kwMap["mom0OuterBond"] = __DO__(conf) { readLawData(conf, idMom0OuterBond); };
   parser.kwMap["powOuterBond"] = __DO__(conf) { readLawData(conf, idPowOuterBond); };
   parser.kwMap["en2OuterBond"] = __DO__(conf) { readLawData(conf, idEn2OuterBond); };
-  
+
   parser.kwMap["gcInnerBond"] = __DO__(conf) { readLawData(conf, idGcInnerBond); };
   parser.kwMap["gcOuterBond"] = __DO__(conf) { readLawData(conf, idGcOuterBond); };
 
@@ -909,9 +923,9 @@ void Rockable::initParser() {
       }
       conf >> P.group >> P.cluster >> P.homothety >> P.pos >> P.vel >> P.acc >> P.Q >> P.vrot >> P.arot;
       if (useSoftParticles == 1) {
-        //conf >> P.uniformTransformation;
+        // conf >> P.uniformTransformation;
       } else {
-        //P.uniformTransformation = mat9r::unit();
+        // P.uniformTransformation = mat9r::unit();
       }
 
       P.shape = &(Shapes[shapeId[shpName]]);  // Plug to the shape
@@ -1043,7 +1057,8 @@ void Rockable::initParser() {
   //          They are generally put at the end of the input file
   //          so that they apply on a system already set
 
-  const std::string commands[] = {"stickBCM", "stickVerticesInClusters",
+  const std::string commands[] = {"stickBCM",
+                                  "stickVerticesInClusters",
                                   "stickVerticesInClustersMoments",
                                   "stickClusters",
                                   "randomlyOrientedVelocities",
@@ -2860,7 +2875,7 @@ void Rockable::initialise_particle_forces_and_moments() {
     Particles[i].acc.reset();
     Particles[i].moment.reset();
     Particles[i].arot.reset();
-    //Particles[i].stress.reset();
+    // Particles[i].stress.reset();
   }
 #ifdef ROCKABLE_ENABLE_PERIODIC
   if (usePeriodicCell == 1) {
@@ -3032,7 +3047,7 @@ inline bool Rockable::computeInterArray()  // TODO change name
 {
   START_TIMER("build_active_interactions");
   unsigned long part_size = 0;
-  //unsigned long offsets[Interactions.size()]; // vr: Variable Lenght Array is C99
+  // unsigned long offsets[Interactions.size()]; // vr: Variable Lenght Array is C99
   std::vector<unsigned long> offsets(Interactions.size());
   testInter.resize(m_vecInteractions.size());
 
@@ -3211,6 +3226,27 @@ void Rockable::compute_resultants() {
       }
     }
 
+    if (useKineticStress) {
+      for (size_t i = nDriven; i < Particles.size(); ++i) {
+        vec3r s = Cell.hinv * Particles[i].pos;
+        vec3r u = Cell.vh * s;
+        vec3r v = Particles[i].vel - u;
+        double m = Particles[i].mass;
+
+        Cell.Sig.xx += m * v.x * v.x;
+        Cell.Sig.xy += m * v.x * v.y;
+        Cell.Sig.xz += m * v.x * v.z;
+
+        Cell.Sig.yx += m * v.y * v.x;
+        Cell.Sig.yy += m * v.y * v.y;
+        Cell.Sig.yz += m * v.y * v.z;
+
+        Cell.Sig.zx += m * v.z * v.x;
+        Cell.Sig.zy += m * v.z * v.y;
+        Cell.Sig.zz += m * v.z * v.z;
+      }
+    }
+
   } else {
 
     for (size_t i = 0; i < activeInteractions.size(); ++i) {
@@ -3263,7 +3299,7 @@ void Rockable::compute_SpringJoints() {
 void Rockable::check_breakage_of_interfaces() {
   START_TIMER("check_breakage_of_interfaces");
 
-  for (BreakableInterface* BI : breakableInterfaces) {  
+  for (BreakableInterface* BI : breakableInterfaces) {
 
     if (BI->breakModel == breakModel_Gc) {  // ========================================================
 
@@ -3288,8 +3324,8 @@ void Rockable::check_breakage_of_interfaces() {
       BI->Et = 0.0;
       for (size_t b = 0; b < BI->concernedBonds.size(); ++b) {
         Interaction* I = BI->concernedBonds[b];
-        
-        if (I->dn > BI->dn0) { // FIXME: there should be one dn0 per bond BI->dn0[b]
+
+        if (I->dn > BI->dn0) {  // FIXME: there should be one dn0 per bond BI->dn0[b]
           BI->En += 0.5 * kn * (I->dn - BI->dn0) * (I->dn - BI->dn0);
         }
         BI->Et += 0.5 * kt * norm2(I->ds);
@@ -3348,7 +3384,7 @@ void Rockable::breakage_of_interfaces() {
 
     // First remove the pointer from the global list (avoid dangling)
     auto it_bi_global = std::find(breakableInterfaces.begin(), breakableInterfaces.end(), *BI);
-    if (it_bi_global != breakableInterfaces.end()) {     
+    if (it_bi_global != breakableInterfaces.end()) {
       breakableInterfaces.erase(it_bi_global);  // safe to remove before deletion
     }
 
@@ -3386,18 +3422,19 @@ void Rockable::compute_accelerations_from_resultants() {
 
     // Acceleration of the periodic cell
     mat9r Vhinv = Vcell * Cell.hinv;
-    mat9r deltaSig = Cell.Sig - System.cellControl.Sig;
+    mat9r deltaSig = System.cellControl.Sig - Cell.Sig;  // sign convention changed
+    mat9r dampingForce = Cell.vh * Cell.damping;
     double invMass = 1.0 / Cell.mass;
 
     for (size_t row = 0; row < 3; row++) {
       for (size_t col = 0; col < 3; col++) {
         size_t c = 3 * row + col;
         if (System.cellControl.Drive[c] == ForceDriven) {
-          Cell.ah[c] = 0.0;
+          double drivingForce = 0.0;
           for (size_t s = 0; s < 3; s++) {
-            Cell.ah[c] += Vhinv[3 * row + s] * deltaSig[3 * s + col];
+            drivingForce += Vhinv[3 * row + s] * deltaSig[3 * s + col];
           }
-          Cell.ah[c] *= invMass;
+          Cell.ah[c] = (drivingForce - dampingForce[c]) * invMass;
         }
       }
     }
@@ -3479,7 +3516,10 @@ void Rockable::compute_accelerations_from_resultants() {
 #ifdef ROCKABLE_ENABLE_PERIODIC
     // If there's a periodic cell, the accelerations are rescaled toward reduced coordinates
     if (usePeriodicCell == 1) {
-      Particles[i].acc = Cell.hinv * Particles[i].acc;
+      vec3r s = Particles[i].pos;
+      vec3r ds = Particles[i].vel;
+      vec3r d2r = Particles[i].acc;
+      Particles[i].acc = Cell.hinv * (d2r - 2.0 * Cell.vh * ds - Cell.ah * s);
     }
 #endif
 
@@ -3662,6 +3702,66 @@ void Rockable::accelerations() {
 }
 
 /**
+ * Apply optional periodic-cell drift correction to free-particle velocities.
+ */
+void Rockable::applyPeriodicCellDriftCorrection() {
+  START_TIMER("applyPeriodicCellDriftCorrection");
+
+  if (cellMomentumCorrection > 0.0) {
+    cellMomentumCorrectionC += dt;
+    if (cellMomentumCorrectionC >= cellMomentumCorrection - dt_2) {
+      cellMomentumCorrectionC = 0.0;
+
+      double Px = 0.0, Py = 0.0, Pz = 0.0;
+      double M_total = 0.0;
+
+#pragma omp parallel for reduction(+ : Px, Py, Pz, M_total)
+      for (size_t i = nDriven; i < Particles.size(); i++) {
+        double m = Particles[i].mass;
+        Px += Particles[i].vel.x * m;
+        Py += Particles[i].vel.y * m;
+        Pz += Particles[i].vel.z * m;
+        M_total += m;
+      }
+
+      if (M_total > 0.0) {
+        vec3r v_drift(Px / M_total, Py / M_total, Pz / M_total);
+#pragma omp parallel for
+        for (size_t i = nDriven; i < Particles.size(); i++) {
+          Particles[i].vel -= v_drift;
+        }
+      }
+    }
+  }
+
+  if (cellVelocityCorrection > 0.0) {
+    cellVelocityCorrectionC += dt;
+    if (cellVelocityCorrectionC >= cellVelocityCorrection - dt_2) {
+      cellVelocityCorrectionC = 0.0;
+
+      double Vx = 0.0, Vy = 0.0, Vz = 0.0;
+      size_t N = Particles.size() - nDriven;
+
+#pragma omp parallel for reduction(+ : Vx, Vy, Vz)
+      for (size_t i = nDriven; i < Particles.size(); i++) {
+        Vx += Particles[i].vel.x;
+        Vy += Particles[i].vel.y;
+        Vz += Particles[i].vel.z;
+      }
+
+      if (N > 0) {
+        double invN = 1.0 / static_cast<double>(N);
+        vec3r v_mean(Vx * invN, Vy * invN, Vz * invN);
+#pragma omp parallel for
+        for (size_t i = nDriven; i < Particles.size(); i++) {
+          Particles[i].vel -= v_mean;
+        }
+      }
+    }
+  }
+}
+
+/**
  *   This is the so-called Cundall damping solution
  *
  *   @attention It acts on forces, so call this method after the summation of forces/moment
@@ -3699,6 +3799,13 @@ void Rockable::numericalDamping() {
 
 #pragma omp parallel for default(shared)
   for (size_t i = nDriven; i < Particles.size(); ++i) {
+
+    vec3r vel = Particles[i].vel;
+#ifdef ROCKABLE_ENABLE_PERIODIC
+    if (usePeriodicCell == 1) {
+      vel -= Cell.vhHinv * Particles[i].pos;
+    }
+#endif
 
 #ifdef COMPONENTWISE_NUM_DAMPING
     // Translation

--- a/src/Core/Rockable.cpp
+++ b/src/Core/Rockable.cpp
@@ -1136,6 +1136,14 @@ void Rockable::loadConf(const char* a_name) {
 
   Interactions_from_set_to_vec();
 
+#ifdef ROCKABLE_ENABLE_PERIODIC
+  // IMPORTANT: updateCellDamping() must be called AFTER Interactions_from_set_to_vec()
+  // because it accesses m_vecInteractions which is populated by that function
+  if (usePeriodicCell == 1) {
+    updateCellDamping();
+  }
+#endif
+
   // This is a kind of fake time-step (the time is not incremented)
   // mainly used to compute resultant forces and moments on the particles.
   // It will also populate the vector 'activeInteractions'.
@@ -2124,17 +2132,21 @@ void Rockable::velocityVerletStep() {
   // Free bodies
 #ifdef ROCKABLE_ENABLE_PERIODIC
   if (usePeriodicCell == 1) {
-    vec3r vmean;
+
+    // =============================================================================
+    // DRIFT CORRECTION FOR PERIODIC CELL
+    // =============================================================================
+    // Standard velocity update for all free particles
+#pragma omp parallel for default(shared)
     for (size_t i = nDriven; i < Particles.size(); i++) {
       Particles[i].vel += dt_2 * Particles[i].acc;
-      vmean += Particles[i].vel;
       Particles[i].vrot += dt_2 * Particles[i].arot;
     }
-    vmean /= (double)(Particles.size());
-    for (size_t i = 0; i < Particles.size(); i++) {
-      Particles[i].vel -= vmean;
-    }
 
+    // Apply optional drift correction (momentum or velocity based)
+    applyPeriodicCellDriftCorrection();
+
+    // Update cell velocity
     for (size_t c = 0; c < 9; c++) {
       if (System.cellControl.Drive[c] == ForceDriven) Cell.vh[c] += dt_2 * Cell.ah[c];
     }
@@ -2693,6 +2705,8 @@ void Rockable::integrate() {
 
     if (needUpdate || interVerletC >= interVerlet - dt_2) {
       PerfTimer tm;
+
+      updateCellDamping();
 
 #ifdef ROCKABLE_ENABLE_PERIODIC
       if (usePeriodicCell == 1) {
@@ -3516,10 +3530,22 @@ void Rockable::compute_accelerations_from_resultants() {
 #ifdef ROCKABLE_ENABLE_PERIODIC
     // If there's a periodic cell, the accelerations are rescaled toward reduced coordinates
     if (usePeriodicCell == 1) {
-      vec3r s = Particles[i].pos;
-      vec3r ds = Particles[i].vel;
-      vec3r d2r = Particles[i].acc;
-      Particles[i].acc = Cell.hinv * (d2r - 2.0 * Cell.vh * ds - Cell.ah * s);
+      // 1. Use the real acceleration computed just above
+      vec3r a_real = Particles[i].acc;
+
+      // 2. Get real position and velocity
+      vec3r r = Particles[i].pos;
+      vec3r v = Particles[i].vel;
+
+      // 3. Recover reduced position and reduced velocity
+      vec3r s = Cell.hinv * r;
+      vec3r s_dot = Cell.hinv * (v - (Cell.vh * s));
+
+      // 4. Inertial correction terms in reduced frame
+      vec3r inertial = (Cell.vh * s_dot) * 2.0 + (Cell.ah * s);
+
+      // 5. Reduced acceleration
+      Particles[i].acc = Cell.hinv * (a_real - inertial);
     }
 #endif
 
@@ -3700,6 +3726,23 @@ void Rockable::accelerations() {
     applyAngularVelocityBarrier();
   }
 }
+
+#ifdef ROCKABLE_ENABLE_PERIODIC
+void Rockable::updateCellDamping() {
+  if (usePeriodicCell != 1) return;
+
+  if (cellMassRatio > 0.0) {
+    double M_total = 0.0;
+#pragma omp parallel for reduction(+ : M_total)
+    for (size_t i = 0; i < Particles.size(); ++i) {
+      M_total += Particles[i].mass;
+    }
+    if (M_total > 0.0) {
+      Cell.mass = cellMassRatio * M_total;
+    }
+  }
+}
+#endif
 
 /**
  * Apply optional periodic-cell drift correction to free-particle velocities.

--- a/src/Core/Rockable.hpp
+++ b/src/Core/Rockable.hpp
@@ -128,6 +128,13 @@ class Rockable {
 #ifdef ROCKABLE_ENABLE_PERIODIC
   int usePeriodicCell;  ///< Flag indicating if periodic cell is used
   PeriodicCell Cell;    ///< The periodic cell
+  std::vector<std::pair<std::string, int>> periodicBound;  ///< Deferred behavior state for periodic boundaries
+  double cellMomentumCorrection = 0.0;   ///< Time interval for momentum correction (0 = disabled)
+  double cellMomentumCorrectionC = 0.0;  ///< Counter for momentum correction
+  double cellVelocityCorrection = 0.0;   ///< Time interval for velocity correction (0 = disabled)
+  double cellVelocityCorrectionC = 0.0;  ///< Counter for velocity correction
+  double cellMassRatio = -1.0;           ///< Mass ratio override for the periodic cell (-1 = disabled)
+  bool useKineticStress = true;          ///< Flag indicating if kinetic stress contribution is used
 #endif
 
   int useSoftParticles;  ///< Flag indicating if soft particles are used
@@ -290,6 +297,7 @@ class Rockable {
   // =============================================================================================================
 
   void velocityControlledDrive();      ///< Impose the velocities of driven bodies
+  void applyPeriodicCellDriftCorrection();   ///< Apply momentum/velocity drift correction for periodic cell
   void numericalDamping();             ///< The Cundall damping solution
   void applyVelocityBarrier();         ///< The velocity barrier solution
   void applyAngularVelocityBarrier();  ///< The velocity barrier solution for rotations

--- a/src/Core/Rockable.hpp
+++ b/src/Core/Rockable.hpp
@@ -128,7 +128,6 @@ class Rockable {
 #ifdef ROCKABLE_ENABLE_PERIODIC
   int usePeriodicCell;  ///< Flag indicating if periodic cell is used
   PeriodicCell Cell;    ///< The periodic cell
-  std::vector<std::pair<std::string, int>> periodicBound;  ///< Deferred behavior state for periodic boundaries
   double cellMomentumCorrection = 0.0;   ///< Time interval for momentum correction (0 = disabled)
   double cellMomentumCorrectionC = 0.0;  ///< Counter for momentum correction
   double cellVelocityCorrection = 0.0;   ///< Time interval for velocity correction (0 = disabled)
@@ -298,6 +297,7 @@ class Rockable {
 
   void velocityControlledDrive();      ///< Impose the velocities of driven bodies
   void applyPeriodicCellDriftCorrection();   ///< Apply momentum/velocity drift correction for periodic cell
+  void updateCellDamping();                  ///< Update Cell mass based on periodic mass ratio
   void numericalDamping();             ///< The Cundall damping solution
   void applyVelocityBarrier();         ///< The velocity barrier solution
   void applyAngularVelocityBarrier();  ///< The velocity barrier solution for rotations


### PR DESCRIPTION
The main changes include new loading modes, improved handling of periodic cell dynamics (including drift corrections and kinetic stress), and various bug fixes and refactorings.

**Periodic Cell Mechanics and Corrections:**

- Added new member variables to `PeriodicCell` and `Rockable` classes for storing cached matrix products (`vhHinv`, `hinvVh`), damping parameters, mass ratio, drift correction intervals, and a flag for kinetic stress contribution. [[1]](diffhunk://#diff-1fa160a3abf6bd935495d728461a695a5de75ff9721680671fff10c8e9c46785R47-R58) [[2]](diffhunk://#diff-78cc1741a0789252c6a509ac9253004b13ed2c61de604a084d2830d6d0e32c2bR131-R137)
- Implemented drift correction methods in `Rockable` to periodically remove linear momentum or velocity drift from free particles in periodic simulations. [[1]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afR3704-R3763) [[2]](diffhunk://#diff-78cc1741a0789252c6a509ac9253004b13ed2c61de604a084d2830d6d0e32c2bR300)
- Updated the periodic cell acceleration calculation to include damping forces and corrected the sign convention for stress differences.
- Modified the acceleration transformation for particles in periodic cells to account for cell motion and acceleration, improving physical accuracy.
- Enhanced numerical damping to subtract the collective velocity of the periodic cell from particle velocities, ensuring damping is applied in the cell's frame.

**Loading Modes and Boundary Conditions:**

- Added support for new loading modes: `TriaxialCompression` and `SimpleShearDeformable`, including parsing, drive/stress setup, and servo functions.
- Fixed pressure sign convention in `DrivingSystem::read` and corrected assignment of shear/velocity-driven components.

**Configuration and State Management:**

- Extended configuration save/load and parser logic to include new periodic cell parameters (`cellMassRatio`, `damping`, drift corrections, and kinetic stress flag). [[1]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL517-R527) [[2]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL706-R720)
- Set default values for new periodic cell parameters in the constructor.

**Physics and Algorithm Improvements:**

- Implemented kinetic stress contribution to the cell stress tensor, optionally including particle velocity fluctuations in the stress calculation.

These updates collectively improve the fidelity, flexibility, and numerical stability of simulations involving periodic boundary conditions and complex loading scenarios.

**References:**  
[[1]](diffhunk://#diff-1fa160a3abf6bd935495d728461a695a5de75ff9721680671fff10c8e9c46785R47-R58) [[2]](diffhunk://#diff-78cc1741a0789252c6a509ac9253004b13ed2c61de604a084d2830d6d0e32c2bR131-R137) [[3]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afR3704-R3763) [[4]](diffhunk://#diff-78cc1741a0789252c6a509ac9253004b13ed2c61de604a084d2830d6d0e32c2bR300) [[5]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL3389-R3437) [[6]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL3482-R3522) [[7]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afR3803-R3809) [[8]](diffhunk://#diff-9b84334c21f076b4078ec08ceafb3592b6929a9e2fd412fabed4883e54280cabR94-R168) [[9]](diffhunk://#diff-9b84334c21f076b4078ec08ceafb3592b6929a9e2fd412fabed4883e54280cabL83-R85) [[10]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL517-R527) [[11]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL706-R720) [[12]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afR101-R106) [[13]](diffhunk://#diff-c1690d2ced1425238d745f7621a5f332984e87bc0175314cef5aaece1787ea7cL46-R50) [[14]](diffhunk://#diff-c1690d2ced1425238d745f7621a5f332984e87bc0175314cef5aaece1787ea7cL55-R59) [[15]](diffhunk://#diff-c1690d2ced1425238d745f7621a5f332984e87bc0175314cef5aaece1787ea7cL70-R74) [[16]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afR47-L49) [[17]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afL1046-R1061) [[18]](diffhunk://#diff-685ddd6d41e58b57264d0a1e7646354f06f5e9ba01d1dae8ee020fc3347163afR3229-R3249)